### PR TITLE
Fixed Powerup Spawn

### DIFF
--- a/Assets/Prefabs/Misc Structures/radioTower.prefab
+++ b/Assets/Prefabs/Misc Structures/radioTower.prefab
@@ -1079,7 +1079,6 @@ GameObject:
   m_Component:
   - component: {fileID: 6047779140983141369}
   - component: {fileID: 294072498}
-  - component: {fileID: 1404939071359361113}
   - component: {fileID: 294072497}
   m_Layer: 0
   m_Name: radioTower
@@ -1124,18 +1123,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1.4017105, y: 19.899347, z: 1.876585}
   m_Center: {x: -0.20085526, y: -3.9132204, z: 0.4382925}
---- !u!114 &1404939071359361113
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6047779140983141350}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fa0c05fa731e74d4cb7bc748db8f28d3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &294072497
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1159,6 +1146,7 @@ MonoBehaviour:
   shakeRange: 700
   sinkDistance: 300
   sinkSpeed: 2
+  hitCount: 0
   destructionNum: 2
   buildingHit: 0
   isShaking: 0

--- a/Assets/Scripts/Powerups/LaserVision.cs
+++ b/Assets/Scripts/Powerups/LaserVision.cs
@@ -66,7 +66,7 @@ public class LaserVision : MonoBehaviour
         if (Physics.Raycast(line.transform.position, line.transform.forward, out hit, 100, mask))
         {
             // instantiate the explosion and move it to where the laser hit
-            GameObject instance = Instantiate(explosion, gameObject.transform);
+            GameObject instance = Instantiate(explosion, gameObject.transform.position, Quaternion.Euler(90, 0, 0));
             instance.transform.position = hit.transform.position;
         }
         ++shotsTaken;

--- a/Assets/Scripts/RadioTowerPowerupDrop.cs
+++ b/Assets/Scripts/RadioTowerPowerupDrop.cs
@@ -4,34 +4,44 @@ using UnityEngine;
 
 public class RadioTowerPowerupDrop : MonoBehaviour
 {
-    BuildingCollision radioTower;
+    public GameObject[] radioTowerPos;
+    public Vector3[] originPos;
+    Vector3 pickupPos;
 
-    Vector3 originPosition;
-    Vector3 pickupPosition;
+    public bool[] hasSpawned;
 
     public GameObject pickup;
 
     public float setHeight;
 
-    bool hasSpawned;
+
 
 
     void Start()
     {
-        hasSpawned = false;
-        originPosition = transform.position;
-        radioTower = GetComponent<BuildingCollision>();
+        originPos = new Vector3[radioTowerPos.Length];
+        hasSpawned = new bool[radioTowerPos.Length];
+
+        for (int i = 0; i < radioTowerPos.Length; ++i)
+        {
+            originPos[i] = new Vector3(radioTowerPos[i].transform.position.x,
+                                        radioTowerPos[i].transform.position.y,
+                                        radioTowerPos[i].transform.position.z);
+            hasSpawned[i] = false;
+        }
     }
 
     void Update()
     {
-        if ((radioTower.hitCount >= radioTower.destructionNum) && !hasSpawned)
+        for (int i = 0; i < radioTowerPos.Length; i++)
         {
-            originPosition = transform.position;
-            pickupPosition = new Vector3(originPosition.x, setHeight, originPosition.z);
-            Instantiate(pickup, pickupPosition, Quaternion.identity);
+            if (radioTowerPos[i] == null && hasSpawned[i] == false)
+            {
+                pickupPos = new Vector3(originPos[i].x, setHeight, originPos[i].z);
+                Instantiate(pickup, pickupPos, Quaternion.identity);
 
-            hasSpawned = true;
+                hasSpawned[i] = true;
+            }
         }
     }
 }


### PR DESCRIPTION
- The powerup now spawns when the tower is completely destroyed.

- The powerup spawn script is in the powerup manager now and can easily be adjusted for more radio tower locations.

- I also believe I've fixed the laser shot explosion rotation.